### PR TITLE
Fix Inconsistent type for RemoveNullOrWhiteSpace and RemoveNullOrEmpty

### DIFF
--- a/src/Soenneker.Extensions.Enumerable.String/EnumerableStringExtension.cs
+++ b/src/Soenneker.Extensions.Enumerable.String/EnumerableStringExtension.cs
@@ -424,6 +424,9 @@ public static class EnumerableStringExtension
         return ExceptNullOrEmpty(source);
     }
 
+    /// <summary>
+    /// Removes null or empty strings from the <paramref name="source"/>.
+    /// </summary>
     [Pure]
     public static IEnumerable<string> ExceptNullOrEmpty(this IEnumerable<string?> source)
     {
@@ -443,6 +446,9 @@ public static class EnumerableStringExtension
         return ExceptNullOrWhiteSpace(source);
     }
 
+    /// <summary>
+    /// Removes null or white space strings from the <paramref name="source"/>.
+    /// </summary>
     [Pure]
     public static IEnumerable<string> ExceptNullOrWhiteSpace(this IEnumerable<string?> source)
     {

--- a/src/Soenneker.Extensions.Enumerable.String/EnumerableStringExtension.cs
+++ b/src/Soenneker.Extensions.Enumerable.String/EnumerableStringExtension.cs
@@ -418,7 +418,14 @@ public static class EnumerableStringExtension
     }
 
     [Pure]
+    [Obsolete("Use ExceptNullOrEmpty instead")]
     public static IEnumerable<string> RemoveNullOrEmpty(this IEnumerable<string> source)
+    {
+        return ExceptNullOrEmpty(source);
+    }
+
+    [Pure]
+    public static IEnumerable<string> ExceptNullOrEmpty(this IEnumerable<string?> source)
     {
         ArgumentNullException.ThrowIfNull(source);
 
@@ -430,7 +437,14 @@ public static class EnumerableStringExtension
     }
 
     [Pure]
+    [Obsolete("Use ExceptNullOrWhiteSpace instead")]
     public static IEnumerable<string> RemoveNullOrWhiteSpace(this IEnumerable<string> source)
+    {
+        return ExceptNullOrWhiteSpace(source);
+    }
+
+    [Pure]
+    public static IEnumerable<string> ExceptNullOrWhiteSpace(this IEnumerable<string?> source)
     {
         ArgumentNullException.ThrowIfNull(source);
 

--- a/test/Soenneker.Extensions.Enumerable.String.Tests/EnumerableStringExtensionTests.cs
+++ b/test/Soenneker.Extensions.Enumerable.String.Tests/EnumerableStringExtensionTests.cs
@@ -101,11 +101,31 @@ public class EnumerableStringExtensionTests : UnitTest
     }
 
     [Test]
+    public void ExceptNullOrEmpty_ShouldRemoveEmptyStrings()
+    {
+        var input = new List<string?> { "one", "", null, "two" };
+
+        IEnumerable<string> result = input.ExceptNullOrEmpty();
+
+        result.Should().BeEquivalentTo(new List<string> { "one", "two" });
+    }
+
+    [Test]
     public void RemoveNullOrWhiteSpace_ShouldRemoveWhiteSpaceStrings()
     {
         var input = new List<string> { "one", "  ", null, "two" };
 
         IEnumerable<string> result = input.RemoveNullOrWhiteSpace();
+
+        result.Should().BeEquivalentTo(new List<string> { "one", "two" });
+    }
+
+    [Test]
+    public void ExceptNullOrWhiteSpace_ShouldRemoveWhiteSpaceStrings()
+    {
+        var input = new List<string?> { "one", "  ", null, "two" };
+
+        IEnumerable<string> result = input.ExceptNullOrWhiteSpace();
 
         result.Should().BeEquivalentTo(new List<string> { "one", "two" });
     }


### PR DESCRIPTION
﻿<!-- Pull Request Template -->

## Description

The input type for these two methods should be IEnumerable<string?> as they both expect potentially `null` strings as input.

Fixes: #1666 

---

## Type of Change

Please delete options that are not relevant.

- [x ] 🐛 Bug fix
- [ x] 🔧 Refactor
- [x ] ✅ Test improvement

---

## Checklist

- [x ] I’ve added/updated necessary tests
- [ ] I’ve added/updated documentation
- [x ] My code follows the code style of this project
- [ ] I’ve tested this manually

---

## Screenshots / Demo (if applicable)
